### PR TITLE
Controller guide reorganization

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -2,18 +2,22 @@
 layout: post
 title: "Controller Guide"
 draft: false
+href_levels: h2,h3,h4
+sidebar_levels: h2,h3,h4
 ---
 ## Introduction
-Welcome to the Smash 64 controller guide. Unlike the other Smash games, Smash 64 has a wide variety of different controller types, almost all of which see use at high levels of play. This guide outlines the basics of the most popular controller types for competition. All controllers listed in this guide are LEGAL[\*](/guides/controllers.html#appendix) for tournament play in all major tournaments in North America.
-Note that this guide is not exhaustive: any controller that follows the SSB64 League Guidelines (See appendix) may be used in most tournaments, and may not be listed here.
 
+Welcome to the Smash 64 controller guide. Unlike the other Smash games, Smash 64 has a wide variety of different controller types, almost all of which see use at high levels of play. This guide outlines the basics of the most popular controller types for competition. All controllers listed in this guide are **LEGAL[\*](/guides/controllers.html#appendix) for tournament play** in all major tournaments in North America.
 
-#### Choosing a controller
+Note that this guide is not exhaustive: any controller that follows the SSB64 League Guidelines (See [appendix](/guides/controllers.html#appendix)) may be used in most tournaments, and may not be listed here.
+
+## Choosing a Controller
+
 Every controller has its advantages and disadvantages, but none are objectively superior. Before committing to a single controller, try as many options as possible. Tournaments are a great place for this, most people that play with exotic controllers will be happy to let you try them out. Whenever possible, try before you buy. Also, don’t be afraid to switch controllers. Although you might play worse for a short time, switching to a controller you prefer will pay off in the long run.
 
 \* See the [appendix](/guides/controllers.html#appendix) for rules regarding bindings for controllers with adapters.
 
-## Original (OG) N64
+### Original N64 (OG)
 
 ![OG](/guides/img/controllers/OG.png){:width="40%"}<br>
 Estimated Price: **$20 - $50**
@@ -23,224 +27,65 @@ The original N64 controller is by far the most popular controller among casual a
 The OG’s start button can be accidentally pressed during play, disastrous in a tournament setting. Luckily, it’s easy to open the controller and remove the start button. Even without the button, you’ll still be able to press start if you have skinny fingers. The hold-to-pause feature in most patched ROMs makes this less of a concern.
 
 The OG is popular at all levels of competitive play, and is used by many of the strongest players in the world, such as Jouske, Isai, Alvin, and Wario.
-#### How to Obtain
-[N64 Controller Market Group](https://www.facebook.com/groups/n64controllermarket/) - The most reliable source of good controllers. Sellers in this group are almost all smashers, and usually lube the sticks for you. Read the spreadsheets in the pinned post and compare prices. I recommend buying a controller with a 9/10 lubed stick, the difference between a 9/10 and 10/10 is usually fairly marginal. Although you won’t be able to try before you buy, sellers in this group tend to be accurate with their ratings. This is the most expensive and most reliable way to get a good OG controller quickly.
 
-In Person at Tournaments - Most large tournaments will have someone looking to offload a controller or two. Prices and quality will vary, I recommend checking prices against the market group spreadsheets to ensure you’re getting a decent deal. Buying in person at events is a great way to ensure you like the feel of the controller before you buy it.
+##### How to Obtain
 
-[Craigslist](http://craigslist.org)/[eBay](http://www.ebay.com/) - It’s possible to find some great deals on controllers on eBay and Craigslist, but prices and quality vary heavily, and many sellers have no idea how to judge joystick wear. You’ll also have to lubricate the sticks yourself. See the ['Joystick Maintenance and Parts'](https://docs.google.com/document/d/1asbuKPAhHUGWgbJtLg7RJI5Hl_yDTJBlrpEQkgkgvkg/edit#heading=h.nusfzr6s5z49) section of the netplay guide for more information on how to lube a joystick.
-#### Pros/Cons
+**[N64 Controller Market Group](https://www.facebook.com/groups/n64controllermarket/):** The most reliable source of good controllers. Sellers in this group are almost all smashers, and usually lube the sticks for you. Read the spreadsheets in the pinned post and compare prices. I recommend buying a controller with a 9/10 lubed stick, the difference between a 9/10 and 10/10 is usually fairly marginal. Although you won’t be able to try before you buy, sellers in this group tend to be accurate with their ratings. This is the most expensive and most reliable way to get a good OG controller quickly.
+
+**In Person at Tournaments:** Most large tournaments will have someone looking to offload a controller or two. Prices and quality will vary, I recommend checking prices against the market group spreadsheets to ensure you’re getting a decent deal. Buying in person at events is a great way to ensure you like the feel of the controller before you buy it.
+
+**[Craigslist](http://craigslist.org) / [eBay](http://www.ebay.com/):** It’s possible to find some great deals on controllers on eBay and Craigslist, but prices and quality vary heavily, and many sellers have no idea how to judge joystick wear. You’ll also have to lubricate the sticks yourself. See the ['Joystick Maintenance and Parts'](https://docs.google.com/document/d/1asbuKPAhHUGWgbJtLg7RJI5Hl_yDTJBlrpEQkgkgvkg/edit#heading=h.nusfzr6s5z49) section of the netplay guide for more information on how to lube a joystick.
+
+##### Pros / Cons
+
 <p>
-<font color="green">+</font> Button arrangement works well for all characters<br>
-<font color="green">+</font> New joysticks feel great<br>
-<font color="green">+</font> Cheap and common<br>
-<font color="green">+</font> Start button can be temporarily removed<br>
-= Joystick range is normal. DI isn’t as easy as on joysticks with higher range, but tilts are easy.<br>
-<font color="red">-</font> Joystick wears down quickly without lube, making it feel and perform worse<br>
-<font color="red">-</font> Three-prong design can be uncomfortable for some players
-</p>
-### Knockoff Sticks
-
-![Knockoff1](/guides/img/controllers/knockoff1.png)
-![Knockoff2](/guides/img/controllers/knockoff2.jpg){:width="40%"}
-
-OG knockoffs come in two forms: knockoff replacement joysticks, and complete knockoff controllers. Both are generally terrible, with parts that feel cheap and break easily. Knockoff joysticks are known to break completely during play. However, there are some knockoff joysticks which more closely imitate the original and may have parts useful as replacements. Durability of knockoff joysticks tends to be very poor,  and even lubed they will wear out quickly. You can read a review of one knockoff [here](/guides/thumbstick.html), and another [here](/guides/img/controllers/knockoff_review.png).
-
-**WARNING**: Knockoff joystick suppliers are extremely unreliable; just because the picture looks like the original doesn’t mean what you get won’t be total crap. These should only be bought by those that are looking to experiment with new sources and don’t mind possibly wasting their money.
-
-### Lubricants
-
-The OG stick's design causes a lot of wear, especially between the stick and gears and the stick tip and bowl. Most competitive OG users apply lubricant to the internals of their stick to reduce this wear. Sticks may need to be re-lubed every few months, depending on the amount of use. There are many videos online showing the lubrication process, such as [this one](https://www.youtube.com/watch?v=Ar5dF4gp7b8) by top Smash player Fireblaster, which also describes how to install replacement gears. The most important thing to keep in mind when lubing is to avoid getting any lube or dirt in the small encoder wheels, which can cause stick drift and other issues.
-
-Below are some of the most popular lubricants. Lubricant choice is far from an exact science and not every promising lube has been tested, so if you have something you think might work and a spare controller, give it a shot, just make sure it's plastic-safe.
-
-#### Taylor Lube HP
-![taylor lube](/guides/img/controllers/lube/taylor.jpg){:width="20%"}
-
-The ol' reliable, for years this was the only lube in use in the Smash community. Originally meant for frozen yogurt machines, it comes in a giant tube that lasts forever. Gives a smooth feeling. Can be purchased on [Amazon](https://www.amazon.com/Taylor-48232-Tube-Soft-Serve-Lubricant/dp/B009T8PZR2) or various restaurant supply websites.
-
-#### Super Lube PTFE Grease
-![taylor lube](/guides/img/controllers/lube/superlube_small.png){:width="30%"}
-![taylor lube](/guides/img/controllers/lube/superlube_tube.jpg){:width="10%"}
-
-Super Lube is popular with replacement part manufacturers due to its conveniently sized and cheap demo packets (left above) which are good for several sticks. It's also available in more traditional tube sizes. Has a slightly slower or thicker feeling than Taylor Lube. Can be found on [Amazon](https://www.amazon.com/s?k=super+lube+ptfe+grease), eBay, or most hardware stores.
-
-#### Permatex Dielectric Grease
-![Permatex Dielectric Grease](/guides/img/controllers/lube/dielectric.jpg){:width="40%"}
-
-A less widely used grease with a fast and smooth feel. My personal favorite. Can be found on [Amazon](https://www.amazon.com/Permatex-22058-Dielectric-Tune-Up-Grease/dp/B000AL8VD2/), the 0.33 oz tube is plenty for most people.
-
-## Metal Replacement Parts
-
-
-### Steel Stick 64
-[![Steel Stick](/guides/img/controllers/steelstick.png){:width="50%"}](http://steelsticks64.com)
-
-The SteelStick64 is a project currently in progress to create a steel/titanium replacement N64 joystick for greatly increased durability. The project is currently slowly selling sticks to those on a full wait list of 500 people, with full retail release likely years away. Up-to-date information about the project can be found at <http://steelsticks64.com/> and <https://twitter.com/steelsticks64>.
-
-#### Steel Bowl
-[![Steel bowl](/guides/img/controllers/steelbowl.jpg){:width="40%"}](https://steelsticks64.com/?post_type=product)
-
-The creator of the SteelStick occasionally sells stand-alone steel bowls. Because the bowl of the OG wears quickly and has few good replacements, these bowls have been very well  received. They improve stick lifespan and feel, and cost far less than the complete SteelStick.
-
-Steel bowls go on sale in batches at <http://steelsticks64.com/?post_type=product>. Follow SteelSticks on Twitter [@SteelSticks64](https://twitter.com/steelsticks64) or sign up for email alerts on the store page for news when a new batch goes up for sale.
-
-### Oudini Sticks
-[![Oudini Stick](/guides/img/controllers/oudinistick.jpg){:width="40%"}](https://oudini-shop.com/index.php?route=common/home)
-
-Ocarina of Time speedrunner [@ArthurOudini](https://twitter.com/ArthurOudini) has been making his own custom steel sticks. Unlike SteelSticks64, these do not include gears or a bowl and need to be put into an existing module. The price is quite steep for just a stick, but reviews have been positive. More details at [https://oudini-shop.co/](https://oudini-shop.com/)
-
-### TaoStyx64
-[![TaoStyx](/guides/img/controllers/taostyx64.jpg){:width="40%"}](https://taostyx64.com/)
-
-Taostyx has created multiple replacement parts, including their own steel bowls and a variety of joystick caps. They've also released metal buttons and bronze gear teeth available on their [shapeways](https://www.shapeways.com/shops/alinktotao). Reviews in the Smash community so far are scarce. More information at [https://taostyx64.com/](https://taostyx64.com).
-
-## Other replacement parts
-
-### Kitsch-Bent Parts
-[![Kitsch-bent parts](/guides/img/controllers/kitschbent.png){:width="40%"}](https://store.kitsch-bent.com/collections/replacement-parts?filter.p.product_type=Home+Game+Console+Accessories)
-
-Kitsch-Bent sells injection-moulded replacement bowls, sticks, and gears. These parts are extremely cheap but somewhat unrealiable, with some parts coming defective or needing sanding. As such it's usually recommend to order multiples for redudancy and to save on shipping. Due to their low price, KB parts are often used as a starting point for other mods, or paired with more durible steel components. [https://store.kitsch-bent.com](https://store.kitsch-bent.com/collections/replacement-parts?filter.p.product_type=Home+Game+Console+Accessories).
-
-### N64Gears.com
-[![N64Gears](/guides/img/controllers/n64gearslogo.jpg){:width="40%"}](https://www.n64gears.com/)
-
-Injection moulded gears. More expensive than Kitsch-Bent gears, but have recieved some better reviews. Frequently paired with steel sticks and bowls.
-
-
-### eL maN Parts
-[![El Man stick](/guides/img/controllers/elman.png){:width="40%"}](https://elman64.com)
-
-California Smash player eL maN has experimented with various 3D printed and CNC milled replacement parts, such as thinner plastic sticks, brass gears, and brass bowl inserts. His projects have started to catch on as a more affordable way to imitate the SteelStick’s durability and feel.
-
-His latest work can be found on his [Twitter](https://twitter.com/el_man_ton) and website, <https://elman64.com/>
-
-### ReTech Parts
-[![ReTech Stick](/guides/img/controllers/retech.jpg)](https://www.retechmn.com/shop)
-
-The [ReTech](https://www.retechmn.com/shop) project developed a variety of replacement parts, including bowls and sticks, but is currently defunct, and haven't fulfilled all orders.  Follow them at [@retechmn](https://twitter.com/retechmn) on Twitter for updates on their progress.
-
-## GC-Style Replacement Stick
-![Derek stick 1](/guides/img/controllers/derekstick1.png){:width="45%"}
-![Derek stick 2](/guides/img/controllers/derekstick2.png){:width="45%"}<br>
-Estimated Price: **$12**
-
-The “OEM Gamecube Style Replacement Stick”, aka the Derek stick, is a replacement joystick for the OG N64 controller, designed to somewhat mimic the gamecube joystick. The nickname “Derek stick” comes from online player Derek, who brought the stick to the attention of the SSB community in [this thread](https://smashboards.com/threads/n64-controllers-discussion.335532/page-10#post-18614939). The Derek stick is popular among beginning and intermediate players, but aside from [Derek’s legendary GOML](https://www.youtube.com/watch?v=lBBEPqTsIVk) run has seen little use in high-level play.
-
-The Derek stick is unusually short and small, but has input range which slightly exceeds the OG. As a result moves that require small movements, like tilts and uairs, more difficult than usual, while fast inputs like dash dancing feel very responsive.
-
-The are multiple versions of this module, two of which are pictured above. The earliest Derek stick models had severe flaws in input detection that prevented them from being usable in competitive play, but sellers have since updated to newer revisions which resolve the worst of these issues. Buyer beware, some stores may still stock older versions.
-
-There also exists an extensive mod for the Derek Stick that fixes most of the stick’s range and angle-skipping issues. Currently these modded Derek Sticks are not widely distributed and see little use in competitive play, but they show promise. For those with the technical chops to put one together, the modded Derek Stick is an affordable way to make a great stick. More information can be found at the development [thread here](http://nfggames.com/forum2/index.php?topic=5803.0).
-#### How to Obtain
-Many resellers across many websites sell various versions of the Derek stick, and it can be difficult to predict exactly which one you'll recieve. [This source](https://www.amazon.com/gp/product/B0136JPKIS/) seems to have new version along with fast shipping. However, you may be able to find a model you prefer from another source.
-#### Pros/Cons
-<p>
-<font color="green">+</font> Always snaps back quickly to the exact center, with little to no wobble or overshooting<br>
-<font color="green">+</font> Easy to install<br>
-<font color="green">+</font> High range allows for easier DI<br>
-<font color="green">+</font> Cheap and easy to obtain<br>
-<font color="green">+</font> Little to no change in feel, even with heavy use<br>
-<font color="red">-</font> Used sticks may develop drift<br>
-<font color="red">-</font> Although it doesn’t wobble, it has a small deadzone<br>
-<font color="red">-</font> High sensitivity makes moves requiring low ranges (tilts, uairs without jumping, etc.) hard<br>
-<font color="red">-</font> Lack of consistent labeling between brands and versions<br>
+<font color="green"><b>⊕</b></font> Button arrangement works well for all characters<br>
+<font color="green"><b>⊕</b></font> New joysticks feel great<br>
+<font color="green"><b>⊕</b></font> Cheap and common<br>
+<font color="green"><b>⊕</b></font> Start button can be temporarily removed<br>
+<b>⊘</b> Joystick range is normal. DI isn’t as easy as on joysticks with higher range, but tilts are easy.<br>
+<font color="red"><b>⊖</b></font> Joystick wears down quickly without lube, making it feel and perform worse<br>
+<font color="red"><b>⊖</b></font> Three-prong design can be uncomfortable for some players
 </p>
 
-## 8BitDo Hall Effect Joystick
-![8bitdo1](/guides/img/controllers/8bitdo1.jpg){:width="45%"}<br>
-Estimated Price: **$20**
+### Hori Mini Pad
 
-8BitDo, a Chinese manufacturer of popular replacement controllers for modern consoles, released this OG replacement stick in 2023 using hall effect technology. Hall effect sensors are thought to provide better durability than the potentiometers used in normal joysticks, and have become popular in replacement sticks, including the Phob Gamecube controller for Smash Melee.
-
-Like the Derek stick, the 8bitdo stick is an easy-to-install drop-in replacement for the OG's joystick. The cap is larger and made of a nice soft rubber, similar to a Gamecube controller stick. The stick moves smoothly, feels good, and returns to exact center with no wobble. 
-
-Although the 8BitDo's range isn't very high (max of 80), the short cap results in low travel distance and makes the joystick feel fairly sensitive. Those switching from worn OGs may find subtle movements like tilt attacks difficult to perform at first. Higher-level players may find the low range a little limiting for DI.
-
-The stick's durability has yet to be empirically tested due to its recent release, but it should in theory be very long-lasting.
-
-#### How to Obtain
-The 8BitDo stick is available on [their official website](https://shop.8bitdo.com/products/8bitdo-mod-kit-for-original-n64-controller?variant=42721361920177). It's listed alongside their controller mod kit and rumble pack, but neither is required for use. As of July 2023, it requires a backorder, with shipments coming in every month or so.
-#### Pros/Cons
-<p>
-<font color="green">+</font> Always snaps back quickly to the exact center, with little to no wobble or overshooting<br>
-<font color="green">+</font> Easy to install<br>
-<font color="green">+</font> Cheap<br>
-<font color="green">+</font> Comfortable rubber cap<br>
-<font color="green">+</font> Durable design with few points of failure<br>
-<font color="red">-</font> Small and short, making precise inputs difficult<br>
-<font color="red">-</font> Low range hurts DI, and short stick makes some grip changes hard<br>
-</p>
-
-## Retro-bit Analog Repair Module
-![retrobit stick](/guides/img/controllers/retrobit_stick.png){:width="25%"}<br>
-Estimated Price: $15
-
-**DO NOT BUY**. Completely unusable for Smash due to massive input delay, which makes even basic inputs impossible.
-
-
-#### How to Obtain
-Don't.
-
-## Hori Mini Pad
 ![Hori](/guides/img/controllers/hori.png){:width="40%"}<br>
 Estimated Price: **$60-90**
-
 
 The Hori Mini Pad, usually just called the Hori, is a 3rd party N64 released in Japan by Hori Co., a Japanese company known for their fighting game accessories. The Hori differentiates itself from the OG with it’s small size, two handle design, and four triggers, but it’s mostly known for its joystick.
 
 The Hori’s joystick is potentiometer based, similar to the Gamecube’s, which allows for a much longer life with less observable wear than the OG’s. The Hori’s joystick is also much larger than the OG’s, and has a rubber cap instead of the OG’s pure plastic. Perhaps the most distinctive feature of the Hori’s joystick is its looseness. The Hori joystick has extremely little resistance to movement, which gives it a unique feel. The Hori also has high range, which combined with its low resistance makes it extremely good for DI.
 
 The Hori is relatively expensive and takes some getting used to for players familiar with the OG, but it pays off the initial investment with its effective design and long lifespan. The Hori is widely used at all skill levels, and is especially popular with a newer generation of high-level North American players, such as Tacos, Revan, Kero, and Stranded.
-#### How to Obtain
-[eBay](http://www.ebay.com) - You can generally find Horis for fair prices on ebay, make sure you look through a lot of listings to find a decent deal. Horis are less risky to buy on Ebay than OGs, because they’re not as susceptible to wear. That doesn’t mean they’re invincible, though, so be cautious of those that seem heavily used.
 
-[N64 Controller Market Group](https://www.facebook.com/groups/n64controllermarket/)/Tournaments - Similar to buying an OG. Most controller sellers stock Horis and sell at market prices. Some sellers charge more for different colors, so if you’re looking for a specific color make sure to shop around.
-#### Pros/Cons
+##### How to Obtain
+
+**[eBay](http://www.ebay.com):** You can generally find Horis for fair prices on ebay, make sure you look through a lot of listings to find a decent deal. Horis are less risky to buy on Ebay than OGs, because they’re not as susceptible to wear. That doesn’t mean they’re invincible, though, so be cautious of those that seem heavily used.
+
+**[N64 Controller Market Group](https://www.facebook.com/groups/n64controllermarket/) / Tournaments:** Similar to buying an OG. Most controller sellers stock Horis and sell at market prices. Some sellers charge more for different colors, so if you’re looking for a specific color make sure to shop around.
+
+##### Pros / Cons
+
 <p>
-<font color="green">+</font> Large joystick with high range allows for more reliable DI than most OGs, without sacrificing control<br>
-<font color="green">+</font> Joystick wears much slower than OG<br>
-<font color="green">+</font> Trigger design provides easy access to L and R, and two options for pressing Z<br>
-= Very small<br>
-= Two handle design<br>
-= Joystick has a large rubber cap instead of the more common plastic<br>
-<font color="red">-</font> Triggers are small and stiff<br>
-<font color="red">-</font> Start button cannot be temporarily removed<br>
-<font color="red">-</font> Expensive (Often $70+)<br>
-<font color="red">-</font> Been known to have issues with joystick flickback. This is possible to fix through <a href="https://docs.google.com/document/d/1Ql9lpv-qrU2j7pkasYUWFIG4oip5JZdUGtYpLdr3Dz8/edit">hardware modding</a><br>
+<font color="green"><b>⊕</b></font> Large joystick with high range allows for more reliable DI than most OGs, without sacrificing control<br>
+<font color="green"><b>⊕</b></font> Joystick wears much slower than OG<br>
+<font color="green"><b>⊕</b></font> Trigger design provides easy access to L and R, and two options for pressing Z<br>
+<b>⊘</b> Very small<br>
+<b>⊘</b> Two handle design<br>
+<b>⊘</b> Joystick has a large rubber cap instead of the more common plastic<br>
+<font color="red"><b>⊖</b></font> Triggers are small and stiff<br>
+<font color="red"><b>⊖</b></font> Start button cannot be temporarily removed<br>
+<font color="red"><b>⊖</b></font> Expensive (Often $70+)<br>
+<font color="red"><b>⊖</b></font> Been known to have issues with joystick flickback. This is possible to fix through <a href="https://docs.google.com/document/d/1Ql9lpv-qrU2j7pkasYUWFIG4oip5JZdUGtYpLdr3Dz8/edit">hardware modding</a><br>
 </p>
 
-## Hori Clones
+### Hori Clones
 
-In the past few years, a variety of Hori-like controllers have emerged onto the market. Due to their low price and continued production, they're a very accessible option. Their build quality isn't as high as the original Hori, but they're all competitively viable. The current big 3 clones are the Warrior 64, the Retrobit Tribute, and the Chori. The Brawler64 is not quite a Hori clone, but fills a similar function with a more modern form-factor.
+In the past few years, a variety of Hori-like controllers have emerged onto the market. Due to their low price and continued production, they're a very accessible option. Their build quality isn't as high as the original Hori, but they're all competitively viable. The current big 3 clones are the Warrior 64, the Retrobit Tribute, and the "Chori". The Brawler64 is not quite a Hori clone, but fills a similar function with a more modern form-factor.
 
-### Warrior 64
-![Warrior1](/guides/img/controllers/warrior1.png){:width="40%"}
+#### Retro-Bit Tribute 64
 
-Estimated Price: **$20**
-
-Originally released as part of a Kickstarter campaign, the Warrior 64 is the controller that most fully embodies the title of "Hori clone", with an almost exactly identical body design. The shell components aren't quite interchangeable with original Hori parts, but they are exactly the same size. The triggers and buttons are the exact same size and design although the buttons are slightly stiffer.
-
-Like other Hori clones, the Warrior's joystick is a bit stiffer than the ultra-loose one on the original Hori. The stick is also has slightly lower range than Hori, making it less sensitive, although it's still higher than a standard N64 controller.
-
-#### How to Obtain
-[Amazon](https://www.amazon.com/s?k=warrior+64+controller)/eBay - The Warrior is currently being produced and is readily available on most online marketplaces. The MSRP appears to be $20.
-
-
-### Chori
-![Chori](/guides/img/controllers/chori1.jpg){:width="40%"}
-![Chori](/guides/img/controllers/chori2.jpg){:width="40%"}<br>
-Estimated Price: 1 for **$15**. Packs of multiple can be under $10 per controller.
-
-Although given the community name "Chori", this controller is sold under a variety of gibberish brand names, such as miadore, MODESLAB, iNNEXT, kiwitatá, etc. The cheapest of any competitively viable controller, the Chori is frequently sold in packs of two for less than a single controller from an actual brand would cost.
-
-Other than its price, the most noticeable characteristic of the Chori is its wider body and long handles, making it more suitable for players with large hands than the somewhat cramped Hori. Like other Hori clones, the stick is somewhat stiffer and buttons are a bit cheaper feeling, but both are quite functional. The triggers of the Chori are arguably the best of the Hori clones, with a large and flat design that's easy to press from any angle.
-
-
-#### How to Obtain
-Amazon - As mentioned, the Chori is available under a variety of names with no real consistency, the easiest way to identify it is by picture. Searching for "N64 Mini Pad" seems to come up with a lot of Chori results, as well as "N64 controller pack" for bundles. Make sure the listing you find is for the N64 plug version, and USB versions are available.
-
-### Retro-Bit Tribute 64
 ![Tribute2](/guides/img/controllers/tribute2.png){:width="40%"}
 ![Tribute1](/guides/img/controllers/tribute1.png){:width="40%"}<br>
 MSRP:  **$20**
@@ -250,15 +95,44 @@ Released in 2019, the Tribute 64 was the first of the modern Hori remakes. Altho
 Reviews suggest the Tribute’s durability is worse than the Hori’s. Sticky buttons are reported especially often, along with the Hori style joystick malfunctions.
 
 Retrobit has recently announced a wireless version of the Tribute. It has yet to be tested for competitive play.
-#### How to Obtain
-[Amazon](https://www.amazon.com/s?k=tribute+64)/[Retro-Bit](http://retro-bit.com/tribute64#wired-n64) - The Tribute is currently being produced and is readily available on most online marketplaces. Some stores seem to charge more than others based on color; avoid high-priced listings as the official MSRP is $20.
 
+##### How to Obtain
 
-## Retro Fighters Brawler64
+**[Amazon](https://www.amazon.com/s?k=tribute+64) / [Retro-Bit](http://retro-bit.com/tribute64#wired-n64):** The Tribute is currently being produced and is readily available on most online marketplaces. Some stores seem to charge more than others based on color; avoid high-priced listings as the official MSRP is $20.
+
+#### Warrior 64
+
+![Warrior1](/guides/img/controllers/warrior1.png){:width="40%"}
+
+Estimated Price: **$20**
+
+Originally released as part of a Kickstarter campaign, the Warrior 64 is the controller that most fully embodies the title of "Hori clone", with an almost exactly identical body design. The shell components aren't quite interchangeable with original Hori parts, but they are exactly the same size. The triggers and buttons are the exact same size and design although the buttons are slightly stiffer.
+
+Like other Hori clones, the Warrior's joystick is a bit stiffer than the ultra-loose one on the original Hori. The stick is also has slightly lower range than Hori, making it less sensitive, although it's still higher than a standard N64 controller.
+
+###### How to Obtain
+
+**[Amazon](https://www.amazon.com/s?k=warrior+64+controller) / eBay:** The Warrior is currently being produced and is readily available on most online marketplaces. The MSRP appears to be $20.
+
+#### "Chori"
+
+![Chori](/guides/img/controllers/chori1.jpg){:width="40%"}
+![Chori](/guides/img/controllers/chori2.jpg){:width="40%"}<br>
+Estimated Price: 1 for **$15**. Packs of multiple can be under $10 per controller.
+
+Although given the community name "Chori", this controller is sold under a variety of gibberish brand names, such as miadore, MODESLAB, iNNEXT, kiwitatá, etc. The cheapest of any competitively viable controller, the Chori is frequently sold in packs of two for less than a single controller from an actual brand would cost.
+
+Other than its price, the most noticeable characteristic of the Chori is its wider body and long handles, making it more suitable for players with large hands than the somewhat cramped Hori. Like other Hori clones, the stick is somewhat stiffer and buttons are a bit cheaper feeling, but both are quite functional. The triggers of the Chori are arguably the best of the Hori clones, with a large and flat design that's easy to press from any angle.
+
+###### How to Obtain
+
+**Amazon:** As mentioned, the Chori is available under a variety of names with no real consistency, the easiest way to identify it is by picture. Searching for "N64 Mini Pad" seems to come up with a lot of Chori results, as well as "N64 controller pack" for bundles. Make sure the listing you find is for the N64 plug version, and USB versions are available.
+
+### Retro Fighters Brawler64
+
 ![Brawler 64](/guides/img/controllers/brawler1.png){:width="45%"}
 ![Brawler 2](/guides/img/controllers/brawler2.png){:width="45%"}<br>
 Estimated Price: **$35**
-
 
 The Brawler64 is a 3rd-party controller that attempts to more closely mimic modern controller designs. As such it deviates a lot from both the OG and the Hori, and probably as a result, hasn’t caught on much with N64 die-hards.
 
@@ -271,87 +145,276 @@ The Brawler’s joystick is snappy and stiffer than the Hori’s, with range low
 Although rarely enforced, the Brawler’s TURBO button technically violates tournament rules and should be removed.
 
 The Brawler is also available in a wireless version at a slightly higher price (~$45). This version hasn't been tested for competitive play.
-#### How to Obtain
-[Retrofighters website](https://retrofighters.com/our-collection/brawler64-nextgen-n64-controller-original-v2/)/Amazon - The Brawler is currently being produced and is readily available on most online marketplaces, although the price seems to vary. Expect to pay ~$30-35.
-#### Pros/Cons
+
+##### How to Obtain
+
+**[Retrofighters website](https://retrofighters.com/our-collection/brawler64-nextgen-n64-controller-original-v2/) / Amazon:** The Brawler is currently being produced and is readily available on most online marketplaces, although the price seems to vary. Expect to pay ~$30-35.
+
+##### Pros / Cons
+
 <p>
-<font color="green">+</font> Easy to acquire<br>
-<font color="green">+</font> Modern joystick design with consistent feel<br>
-<font color="green">+</font> Start button is far from the joystick and can be removed<br>
-= Larger than the original<br>
-= Very different layout and ergonomics <br>
-<font color="red">-</font> Weird triggers<br>
-<font color="red">-</font> Inconvenient button layout<br>
-<font color="red">-</font> Turbo button<br>
-</p>
-## Gamecube + Raphnet GC to N64 Adapter
-![Gamecube Adapter](/guides/img/controllers/gcadapter.jpg){:width="70%"}<br>
-Adapter Price: **$28**
-
-With the aid of a Raphnet adapter, it’s possible to use a Gamecube controller on the N64. This option is especially popular among Melee and Sm4sh players picking up Smash 64, but its advantages are numerous enough to make it worth considering for Smash 64-only players as well.
-#### How to Obtain
-The adapter can be purchased at [https://www.raphnet-tech.com](https://www.raphnet-tech.com/products/gc_to_n64_adapter_v3_with_builtin_controller_pak/index.php). Gamecube controllers themselves can be bought used on Ebay, Craigslist, retro game stores, etc.
-#### Pros/Cons
-<p>
-<font color="green">+</font> Can be configured to use a square or OG-style octagon gate<br>
-<font color="green">+</font> Medium range with a square gate allows for optimal DI without sacrificing control<br>
-<font color="green">+</font> Joystick is very resistant to wear<br>
-<font color="green">+</font> Gamecube controllers are easy to find<br>
-<font color="green">+</font> Buttons can be easily remapped through the adapter to suit player preferences<br>
-<font color="green">+</font> Start button is far away from joystick, making accidental presses less likely<br>
-<font color="green">+</font> Extra trigger allows L, R, and Z to all be accessible with no hand movement<br>
-= Two handle design<br>
-= Face button layout is different than OG<br>
-<font color="red">-</font> Triggers require modification to be purely digital, otherwise have a sliding section<br>
-<font color="red">-</font> C-Stick’s Melee macro functionality is lost, possibly interfering with some players’ muscle memory<br>
-</p>
-## Keyboard
-![Keyboard](/guides/img/controllers/keyboard.png){:width="60%"}
-
-The popularity of playing Smash 64 online using an emulator has given rise to strong players only used to playing the game on a keyboard. Keyboard play has significant disadvantages over using a controller, but that hasn’t stopped players like StarKing and Killer from scoring big wins with them.
-
-Keyboards can be used on an N64 console with the help of an adapter, however these adapters are currently not mass produced and so are usually custom-made.
-#### How to Obtain
-There are no keyboard adapters currently in production, so you might need to assemble one on your own. Developer Ownasaurus created a successful design in the past, you may be able to find one second-hand or resources to make a new one on the [discord](https://discord.com/invite/ssb64).
-
-#### Pros/Cons
-<p>
-<font color="green">+</font> High range and digital inputs allows for very strong DI<br>
-<font color="green">+</font> Controls can easily be remapped to fit personal preference<br>
-<font color="red">-</font> Many important techniques that rely on analog inputs, such as tilt attacks, firefox angles, shield drop up airs, and many others, are either much more difficult or impossible on keyboard.<br>
-<font color="red">-</font> Keyboard and controller are very different to play on, making transitioning between the two very difficult, especially for players with years of experience on one or the other.<br>
+<font color="green"><b>⊕</b></font> Easy to acquire<br>
+<font color="green"><b>⊕</b></font> Modern joystick design with consistent feel<br>
+<font color="green"><b>⊕</b></font> Start button is far from the joystick and can be removed<br>
+<b>⊘</b> Larger than the original<br>
+<b>⊘</b> Very different layout and ergonomics <br>
+<font color="red"><b>⊖</b></font> Weird triggers<br>
+<font color="red"><b>⊖</b></font> Inconvenient button layout<br>
+<font color="red"><b>⊖</b></font> Turbo button<br>
 </p>
 
-## Lodgenet
+### Lodgenet
+
 ![Lodgenet](/guides/img/controllers/lodgenet.png){:width="40%"}
 
 The LodgeNet controller was created for use in hotel LodgeNet systems, which allowed guests to pay for playtime on N64 games on their room TV. The V1 Lodgenet controller, not pictured, was essentially identical to the OG, with the addition of the Lodgenet buttons replacing the Nintendo logo. The later Lodgenet V2, shown above, improved on its predecessor by replacing the OG joystick with a potentiometer based design created by Hori, and by replacing all button pads with stiffer, clickier versions.
 
 Both versions of the Lodgenet controller are not natively compatible with home N64 systems, and require heavy modification to be usable. The LodgeNet can fail due to wear in a variety of ways (Joystick stalk damage, stickbox failure, Z-trigger pad misalignment) that require understanding of the modded LodgeNet’s internals to fix. Competitive players looking to use the LodgeNet should be aware of these potential problems and keep backups and/or know how to fix possible issues.
-#### How to Obtain
-Unmodified Lodgenet controllers can occasionally be found on Ebay. A guide on how to perform the mod can be found [here](https://www.youtube.com/watch?v=vH1tthMz_YI).
+
+##### How to Obtain
+
+**Ebay:** Unmodified Lodgenet controllers can occasionally be found on Ebay. A guide on how to perform the mod can be found [here](https://www.youtube.com/watch?v=vH1tthMz_YI).
 
 From time to time they may be sold in the N64 Controller Market Group or by modders at tournaments.
-#### Pros/Cons
+
+##### Pros / Cons
+
 <p>
-<font color="green">+</font> Large joystick with high range allows for more reliable DI than most OGs, without sacrificing control<br>
-<font color="green">+</font> Joystick wears slower than OG<br>
-<font color="green">+</font> All buttons and triggers are clickier and less mushy than OG<br>
-<font color="green">+</font> Start button is slightly recessed and stiffer, making accidental presses less common<br>
-<font color="green">+</font> Start button can be temporarily removed<br>
-= Joystick does not have the loose feeling of the Hori<br>
-= Joystick is solid plastic with no rubber cap<br>
-<font color="red">-</font> Sides of joystick wear from collision with gate<br>
-<font color="red">-</font> Quite rare and require a complex mod<br>
+<font color="green"><b>⊕</b></font> Large joystick with high range allows for more reliable DI than most OGs, without sacrificing control<br>
+<font color="green"><b>⊕</b></font> Joystick wears slower than OG<br>
+<font color="green"><b>⊕</b></font> All buttons and triggers are clickier and less mushy than OG<br>
+<font color="green"><b>⊕</b></font> Start button is slightly recessed and stiffer, making accidental presses less common<br>
+<font color="green"><b>⊕</b></font> Start button can be temporarily removed<br>
+<b>⊘</b> Joystick does not have the loose feeling of the Hori<br>
+<b>⊘</b> Joystick is solid plastic with no rubber cap<br>
+<font color="red"><b>⊖</b></font> Sides of joystick wear from collision with gate<br>
+<font color="red"><b>⊖</b></font> Quite rare and require a complex mod<br>
 </p>
-## XBox/Playstation/Misc USB
+
+### GameCube + Adapter
+
+![Gamecube Adapter](/guides/img/controllers/gcadapter.jpg){:width="70%"}<br>
+Adapter Price: **$28**
+
+With the aid of a Raphnet GC to N64 adapter, it’s possible to use a Gamecube controller on the N64. This option is especially popular among Melee and Sm4sh players picking up Smash 64, but its advantages are numerous enough to make it worth considering for Smash 64-only players as well.
+
+##### How to Obtain
+
+**Raphnet website** The adapter can be purchased at [https://www.raphnet-tech.com](https://www.raphnet-tech.com/products/gc_to_n64_adapter_v3_with_builtin_controller_pak/index.php). Gamecube controllers themselves can be bought used on Ebay, Craigslist, retro game stores, etc.
+
+##### Pros / Cons
+
+<p>
+<font color="green"><b>⊕</b></font> Can be configured to use a square or OG-style octagon gate<br>
+<font color="green"><b>⊕</b></font> Medium range with a square gate allows for optimal DI without sacrificing control<br>
+<font color="green"><b>⊕</b></font> Joystick is very resistant to wear<br>
+<font color="green"><b>⊕</b></font> Gamecube controllers are easy to find<br>
+<font color="green"><b>⊕</b></font> Buttons can be easily remapped through the adapter to suit player preferences<br>
+<font color="green"><b>⊕</b></font> Start button is far away from joystick, making accidental presses less likely<br>
+<font color="green"><b>⊕</b></font> Extra trigger allows L, R, and Z to all be accessible with no hand movement<br>
+<b>⊘</b> Two handle design<br>
+<b>⊘</b> Face button layout is different than OG<br>
+<font color="red"><b>⊖</b></font> Triggers require modification to be purely digital, otherwise have a sliding section<br>
+<font color="red"><b>⊖</b></font> C-Stick’s Melee macro functionality is lost, possibly interfering with some players’ muscle memory<br>
+</p>
+
+### Xbox / PlayStation / USB
+
 ![xbox](/guides/img/controllers/xbox.png){:width="40%"}
 ![playstation](/guides/img/controllers/playstation.png){:width="40%"}
 ![keyboard](/guides/img/controllers/keyboard.png){:width="40%"}
 
 Alongside keyboard, many other non-standard controllers see use for online play. All of these currently depend on custom-made adapters, although this may change with the advancement of Ownasaurus’ USB adapter (see Keyboard “How to Obtain” section above). These controllers vary wildly in capability, including many different types joysticks, as well as controllers with no joysticks at all.
+
+### Keyboard
+
+![Keyboard](/guides/img/controllers/keyboard.png){:width="60%"}
+
+The popularity of playing Smash 64 online using an emulator has given rise to strong players only used to playing the game on a keyboard. Keyboard play has significant disadvantages over using a controller, but that hasn’t stopped players like StarKing and Killer from scoring big wins with them.
+
+Keyboards can be used on an N64 console with the help of an adapter, however these adapters are currently not mass produced and so are usually custom-made.
+
+##### How to Obtain
+
+**DIY:** There are no keyboard adapters currently in production, so you might need to assemble one on your own. Developer Ownasaurus created a successful design in the past, you may be able to find one second-hand or resources to make a new one on the [discord](https://discord.com/invite/ssb64).
+
+##### Pros / Cons
+
+<p>
+<font color="green"><b>⊕</b></font> High range and digital inputs allows for very strong DI<br>
+<font color="green"><b>⊕</b></font> Controls can easily be remapped to fit personal preference<br>
+<font color="red"><b>⊖</b></font> Many important techniques that rely on analog inputs, such as tilt attacks, firefox angles, shield drop up airs, and many others, are either much more difficult or impossible on keyboard.<br>
+<font color="red"><b>⊖</b></font> Keyboard and controller are very different to play on, making transitioning between the two very difficult, especially for players with years of experience on one or the other.<br>
+</p>
+
+## Controller Maintenance
+
+### Lubricants
+
+The OG stick's design causes a lot of wear, especially between the stick and gears and the stick tip and bowl. Most competitive OG users apply lubricant to the internals of their stick to reduce this wear. Sticks may need to be re-lubed every few months, depending on the amount of use. There are many videos online showing the lubrication process, such as [this one](https://www.youtube.com/watch?v=Ar5dF4gp7b8) by top Smash player Fireblaster, which also describes how to install replacement gears. The most important thing to keep in mind when lubing is to avoid getting any lube or dirt in the small encoder wheels, which can cause stick drift and other issues.
+
+Below are some of the most popular lubricants. Lubricant choice is far from an exact science and not every promising lube has been tested, so if you have something you think might work and a spare controller, give it a shot, just make sure it's plastic-safe.
+
+##### Taylor Lube HP
+
+![taylor lube](/guides/img/controllers/lube/taylor.jpg){:width="20%"}
+
+The ol' reliable, for years this was the only lube in use in the Smash community. Originally meant for frozen yogurt machines, it comes in a giant tube that lasts forever. Gives a smooth feeling. Can be purchased on [Amazon](https://www.amazon.com/Taylor-48232-Tube-Soft-Serve-Lubricant/dp/B009T8PZR2) or various restaurant supply websites.
+
+##### Super Lube PTFE Grease
+
+![taylor lube](/guides/img/controllers/lube/superlube_small.png){:width="30%"}
+![taylor lube](/guides/img/controllers/lube/superlube_tube.jpg){:width="10%"}
+
+Super Lube is popular with replacement part manufacturers due to its conveniently sized and cheap demo packets (left above) which are good for several sticks. It's also available in more traditional tube sizes. Has a slightly slower or thicker feeling than Taylor Lube. Can be found on [Amazon](https://www.amazon.com/s?k=super+lube+ptfe+grease), eBay, or most hardware stores.
+
+##### Permatex Dielectric Grease
+
+![Permatex Dielectric Grease](/guides/img/controllers/lube/dielectric.jpg){:width="40%"}
+
+A less widely used grease with a fast and smooth feel. My personal favorite. Can be found on [Amazon](https://www.amazon.com/Permatex-22058-Dielectric-Tune-Up-Grease/dp/B000AL8VD2/), the 0.33 oz tube is plenty for most people.
+
+### Metal Replacement Parts
+
+#### Steel Stick 64
+
+[![Steel Stick](/guides/img/controllers/steelstick.png){:width="50%"}](http://steelsticks64.com)
+
+The SteelStick64 is a project currently in progress to create a steel/titanium replacement N64 joystick for greatly increased durability. The project is currently slowly selling sticks to those on a full wait list of 500 people, with full retail release likely years away. Up-to-date information about the project can be found at <http://steelsticks64.com/> and <https://twitter.com/steelsticks64>.
+
+#### Steel Bowl
+
+[![Steel bowl](/guides/img/controllers/steelbowl.jpg){:width="40%"}](https://steelsticks64.com/?post_type=product)
+
+The creator of the SteelStick occasionally sells stand-alone steel bowls. Because the bowl of the OG wears quickly and has few good replacements, these bowls have been very well  received. They improve stick lifespan and feel, and cost far less than the complete SteelStick.
+
+Steel bowls go on sale in batches at <http://steelsticks64.com/?post_type=product>. Follow SteelSticks on Twitter [@SteelSticks64](https://twitter.com/steelsticks64) or sign up for email alerts on the store page for news when a new batch goes up for sale.
+
+#### Oudini Sticks
+
+[![Oudini Stick](/guides/img/controllers/oudinistick.jpg){:width="40%"}](https://oudini-shop.com/index.php?route=common/home)
+
+Ocarina of Time speedrunner [@ArthurOudini](https://twitter.com/ArthurOudini) has been making his own custom steel sticks. Unlike SteelSticks64, these do not include gears or a bowl and need to be put into an existing module. The price is quite steep for just a stick, but reviews have been positive. More details at [https://oudini-shop.co/](https://oudini-shop.com/)
+
+#### TaoStyx64
+
+[![TaoStyx](/guides/img/controllers/taostyx64.jpg){:width="40%"}](https://taostyx64.com/)
+
+Taostyx has created multiple replacement parts, including their own steel bowls and a variety of joystick caps. They've also released metal buttons and bronze gear teeth available on their [shapeways](https://www.shapeways.com/shops/alinktotao). Reviews in the Smash community so far are scarce. More information at [https://taostyx64.com/](https://taostyx64.com).
+
+### Other replacement parts
+
+#### Kitsch-Bent Parts
+
+[![Kitsch-bent parts](/guides/img/controllers/kitschbent.png){:width="40%"}](https://store.kitsch-bent.com/collections/replacement-parts?filter.p.product_type=Home+Game+Console+Accessories)
+
+Kitsch-Bent sells injection-moulded replacement bowls, sticks, and gears. These parts are extremely cheap but somewhat unrealiable, with some parts coming defective or needing sanding. As such it's usually recommend to order multiples for redudancy and to save on shipping. Due to their low price, KB parts are often used as a starting point for other mods, or paired with more durible steel components. [https://store.kitsch-bent.com](https://store.kitsch-bent.com/collections/replacement-parts?filter.p.product_type=Home+Game+Console+Accessories).
+
+#### N64Gears.com
+
+[![N64Gears](/guides/img/controllers/n64gearslogo.jpg){:width="40%"}](https://www.n64gears.com/)
+
+Injection moulded gears. More expensive than Kitsch-Bent gears, but have recieved some better reviews. Frequently paired with steel sticks and bowls.
+
+#### eL maN Parts
+
+[![El Man stick](/guides/img/controllers/elman.png){:width="40%"}](https://elman64.com)
+
+California Smash player eL maN has experimented with various 3D printed and CNC milled replacement parts, such as thinner plastic sticks, brass gears, and brass bowl inserts. His projects have started to catch on as a more affordable way to imitate the SteelStick’s durability and feel.
+
+His latest work can be found on his [Twitter](https://twitter.com/el_man_ton) and website, <https://elman64.com/>
+
+#### ReTech Parts
+
+[![ReTech Stick](/guides/img/controllers/retech.jpg)](https://www.retechmn.com/shop)
+
+The [ReTech](https://www.retechmn.com/shop) project developed a variety of replacement parts, including bowls and sticks, but is currently defunct, and haven't fulfilled all orders.  Follow them at [@retechmn](https://twitter.com/retechmn) on Twitter for updates on their progress.
+
+### Knockoff Sticks
+
+![Knockoff1](/guides/img/controllers/knockoff1.png)
+![Knockoff2](/guides/img/controllers/knockoff2.jpg){:width="40%"}
+
+OG knockoffs come in two forms: knockoff replacement joysticks, and complete knockoff controllers. Both are generally terrible, with parts that feel cheap and break easily. Knockoff joysticks are known to break completely during play. However, there are some knockoff joysticks which more closely imitate the original and may have parts useful as replacements. Durability of knockoff joysticks tends to be very poor,  and even lubed they will wear out quickly. You can read a review of one knockoff [here](/guides/thumbstick.html), and another [here](/guides/img/controllers/knockoff_review.png).
+
+**WARNING**: Knockoff joystick suppliers are extremely unreliable; just because the picture looks like the original doesn’t mean what you get won’t be total crap. These should only be bought by those that are looking to experiment with new sources and don’t mind possibly wasting their money.
+
+### GameCube-Style Stick
+
+![Derek stick 1](/guides/img/controllers/derekstick1.png){:width="45%"}
+![Derek stick 2](/guides/img/controllers/derekstick2.png){:width="45%"}<br>
+Estimated Price: **$12**
+
+The “OEM Gamecube Style Replacement Stick”, aka the Derek stick, is a replacement joystick for the OG N64 controller, designed to somewhat mimic the gamecube joystick. The nickname “Derek stick” comes from online player Derek, who brought the stick to the attention of the SSB community in [this thread](https://smashboards.com/threads/n64-controllers-discussion.335532/page-10#post-18614939). The Derek stick is popular among beginning and intermediate players, but aside from [Derek’s legendary GOML](https://www.youtube.com/watch?v=lBBEPqTsIVk) run has seen little use in high-level play.
+
+The Derek stick is unusually short and small, but has input range which slightly exceeds the OG. As a result moves that require small movements, like tilts and uairs, more difficult than usual, while fast inputs like dash dancing feel very responsive.
+
+The are multiple versions of this module, two of which are pictured above. The earliest Derek stick models had severe flaws in input detection that prevented them from being usable in competitive play, but sellers have since updated to newer revisions which resolve the worst of these issues. Buyer beware, some stores may still stock older versions.
+
+There also exists an extensive mod for the Derek Stick that fixes most of the stick’s range and angle-skipping issues. Currently these modded Derek Sticks are not widely distributed and see little use in competitive play, but they show promise. For those with the technical chops to put one together, the modded Derek Stick is an affordable way to make a great stick. More information can be found at the development [thread here](http://nfggames.com/forum2/index.php?topic=5803.0).
+
+##### How to Obtain
+
+**Various:** Many resellers across many websites sell various versions of the Derek stick, and it can be difficult to predict exactly which one you'll recieve. [This source](https://www.amazon.com/gp/product/B0136JPKIS/) seems to have new version along with fast shipping. However, you may be able to find a model you prefer from another source.
+
+##### Pros / Cons
+
+<p>
+<font color="green"><b>⊕</b></font> Always snaps back quickly to the exact center, with little to no wobble or overshooting<br>
+<font color="green"><b>⊕</b></font> Easy to install<br>
+<font color="green"><b>⊕</b></font> High range allows for easier DI<br>
+<font color="green"><b>⊕</b></font> Cheap and easy to obtain<br>
+<font color="green"><b>⊕</b></font> Little to no change in feel, even with heavy use<br>
+<font color="red"><b>⊖</b></font> Used sticks may develop drift<br>
+<font color="red"><b>⊖</b></font> Although it doesn’t wobble, it has a small deadzone<br>
+<font color="red"><b>⊖</b></font> High sensitivity makes moves requiring low ranges (tilts, uairs without jumping, etc.) hard<br>
+<font color="red"><b>⊖</b></font> Lack of consistent labeling between brands and versions<br>
+</p>
+
+### 8BitDo Hall Effect Joystick
+
+![8bitdo1](/guides/img/controllers/8bitdo1.jpg){:width="45%"}<br>
+Estimated Price: **$20**
+
+8BitDo, a Chinese manufacturer of popular replacement controllers for modern consoles, released this OG replacement stick in 2023 using hall effect technology. Hall effect sensors are thought to provide better durability than the potentiometers used in normal joysticks, and have become popular in replacement sticks, including the Phob Gamecube controller for Smash Melee.
+
+Like the Derek stick, the 8bitdo stick is an easy-to-install drop-in replacement for the OG's joystick. The cap is larger and made of a nice soft rubber, similar to a Gamecube controller stick. The stick moves smoothly, feels good, and returns to exact center with no wobble. 
+
+Although the 8BitDo's range isn't very high (max of 80), the short cap results in low travel distance and makes the joystick feel fairly sensitive. Those switching from worn OGs may find subtle movements like tilt attacks difficult to perform at first. Higher-level players may find the low range a little limiting for DI.
+
+The stick's durability has yet to be empirically tested due to its recent release, but it should in theory be very long-lasting.
+
+##### How to Obtain
+
+**8bitdo.com:** The 8BitDo stick is available on [their official website](https://shop.8bitdo.com/products/8bitdo-mod-kit-for-original-n64-controller?variant=42721361920177). It's listed alongside their controller mod kit and rumble pack, but neither is required for use. As of July 2023, it requires a backorder, with shipments coming in every month or so.
+
+##### Pros / Cons
+
+<p>
+<font color="green"><b>⊕</b></font> Always snaps back quickly to the exact center, with little to no wobble or overshooting<br>
+<font color="green"><b>⊕</b></font> Easy to install<br>
+<font color="green"><b>⊕</b></font> Cheap<br>
+<font color="green"><b>⊕</b></font> Comfortable rubber cap<br>
+<font color="green"><b>⊕</b></font> Durable design with few points of failure<br>
+<font color="red"><b>⊖</b></font> Small and short, making precise inputs difficult<br>
+<font color="red"><b>⊖</b></font> Low range hurts DI, and short stick makes some grip changes hard<br>
+</p>
+
+### Retro-bit Repair Module
+
+![retrobit stick](/guides/img/controllers/retrobit_stick.png){:width="25%"}<br>
+Estimated Price: $15
+
+**DO NOT BUY**. Completely unusable for Smash due to massive input delay, which makes even basic inputs impossible.
+
+##### How to Obtain
+
+**Don't.**
+
 ## Appendix
-#### Official Controller Ruleset
+
+### Official Controller Ruleset
+
 The official SSB64 League ruleset includes a section on controllers restrictions:
 
 > All controllers are subject to the following restrictions:
@@ -366,13 +429,12 @@ In essence, these rules restrict using additional duplicate buttons that aren’
 
 Please note that this is just the suggested ruleset! Any individual tournament may have its own rules regarding controllers, and you should check the rules of any tournament you plan to attend before you sign up.
 
-
 A few important cases under the League ruleset:
 
-**Button rebinding** - Some players use electronic mods to swap one of their C buttons with the L trigger for easy access to taunt. This is legal under this ruleset, so long as the original L button is either bound to the replaced C button, or unbound, since you may not have 2 L buttons.
+**Button rebinding:** Some players use electronic mods to swap one of their C buttons with the L trigger for easy access to taunt. This is legal under this ruleset, so long as the original L button is either bound to the replaced C button, or unbound, since you may not have 2 L buttons.
 
-**Dpad Binding** - Some GC controller users have rebound their dpads to additional joystick inputs to improve their DI. This is banned under the official ruleset, under the “Maximum of 4 directional mappings” clause.
+**Dpad Binding:** Some GC controller users have rebound their dpads to additional joystick inputs to improve their DI. This is banned under the official ruleset, under the “Maximum of 4 directional mappings” clause.
 
-#### Credits
+### Credits
+
 This guide was created by nickthename from the [SSB64 Discord](https://discord.gg/ssb64) server. Send complaints or questions to me there. Thanks to Zantetsu, Annex, and Pizza for suggestions.
-


### PR DESCRIPTION
This change uses some of the front matter settings from #2. 

Primarily, this defines 2 distinct sections, controller selection and maintenance, instead of mixing them together. I think this ends up being a bit easier to navigate.

I suspect, originally, you wanted to keep all OG controller information at the top, so I'm wondering what you think of this layout? If you really want to keep it organized that way, I also thought of having explicit first, second, third party controllers, and via adapters headings.

There are a few minor tweaks in formatting, but no other content changes.